### PR TITLE
Add track stats, daily heatmap, and top tracks endpoints

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -108,6 +108,12 @@ func main() {
 	/* NEW: endpoint to store (or rotate) refresh_token */
 	router.POST("/save-refresh", handlers.SaveRefresh)
 
+	/* Track detail endpoints */
+	router.GET("/tracks/:id/streak", handlers.GetTrackStreak)
+	router.GET("/tracks/:id/stats", handlers.GetTrackStats)
+	router.GET("/tracks/:id/daily", handlers.GetTrackDaily)
+	router.GET("/top-tracks", handlers.GetTopTracks)
+
 	/* Analytics endpoints */
 	router.GET("/collection-stats", handlers.GetCollectionStats)
 	router.GET("/listening-stats", handlers.GetListeningStats)


### PR DESCRIPTION
Three new music journal endpoints: per-track aggregate stats with date filtering, per-day play counts for heatmap calendar, and ranked top tracks with album art. Includes shared date-range parser and NULL-safe handling for empty date ranges.