### PR TITLE
Restore /top-tracks and /listening-stats endpoints lost from source

### DIFF
--- a/cmd/recovery-safe/main.go
+++ b/cmd/recovery-safe/main.go
@@ -128,6 +128,7 @@ func recoverRecentlyPlayedSafe(accessToken string, rateLimiter *utils.RateLimite
 			item.Track.Album.Name,
 			albumCoverURL,
 			genre,
+			item.Track.DurationMs,
 			item.PlayedAt,
 		)
 		if err != nil {

--- a/cmd/recovery/main.go
+++ b/cmd/recovery/main.go
@@ -109,6 +109,7 @@ func recoverRecentlyPlayed(accessToken string, startDate time.Time) {
 			item.Track.Album.Name,
 			albumCoverURL,
 			genre,
+			item.Track.DurationMs,
 			item.PlayedAt,
 		)
 		if err != nil {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -110,6 +110,8 @@ func main() {
 
 	/* Analytics endpoints */
 	router.GET("/collection-stats", handlers.GetCollectionStats)
+	router.GET("/top-tracks", handlers.GetTopTracks)
+	router.GET("/listening-stats", handlers.GetListeningStats)
 
 	/* NEW: start the background cron in its own goroutine */
 	go handlers.StartSpotifyCron()

--- a/internal/handlers/tracks.go
+++ b/internal/handlers/tracks.go
@@ -22,6 +22,132 @@ import (
 // Global rate limiter for cron jobs
 var cronRateLimiter *utils.RateLimiter
 
+/* ---------- top played tracks within a date range ---------- */
+// rankedTopTrack is the JSON shape of one row in the GET /top-tracks response.
+type rankedTopTrack struct {
+	Rank          int    `json:"rank"`
+	SongID        string `json:"song_id"`
+	TrackName     string `json:"track_name"`
+	ArtistName    string `json:"artist_name"`
+	AlbumName     string `json:"album_name"`
+	AlbumCoverURL string `json:"album_cover_url"`
+	PlayCount     int    `json:"play_count"`
+	TotalMs       int64  `json:"total_ms"`
+	Formatted     string `json:"formatted"`
+}
+
+func GetTopTracks(c *gin.Context) {
+	const dateLayout = "2006-01-02"
+	const defaultLimit = 20
+	const maxLimit = 200
+
+	fromStr := c.Query("from")
+	toStr := c.Query("to")
+	limitStr := c.Query("limit")
+
+	var from, to time.Time
+	if fromStr != "" {
+		t, err := time.Parse(dateLayout, fromStr)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid 'from' date, expected YYYY-MM-DD"})
+			return
+		}
+		from = t
+	}
+	if toStr != "" {
+		t, err := time.Parse(dateLayout, toStr)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid 'to' date, expected YYYY-MM-DD"})
+			return
+		}
+		// Live API treats `to` as inclusive of the entire day.
+		to = t.AddDate(0, 0, 1)
+	}
+
+	limit := defaultLimit
+	if limitStr != "" {
+		n, err := strconv.Atoi(limitStr)
+		if err != nil || n <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid 'limit', must be a positive integer"})
+			return
+		}
+		if n > maxLimit {
+			n = maxLimit
+		}
+		limit = n
+	}
+
+	rows, err := repository.GetTopTracks(from, to, limit)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch top tracks", "details": err.Error()})
+		return
+	}
+
+	tracks := make([]rankedTopTrack, len(rows))
+	for i, r := range rows {
+		tracks[i] = rankedTopTrack{
+			Rank:          i + 1,
+			SongID:        r.SpotifySongID,
+			TrackName:     r.TrackName,
+			ArtistName:    r.ArtistName,
+			AlbumName:     r.AlbumName,
+			AlbumCoverURL: r.AlbumCoverURL,
+			PlayCount:     r.PlayCount,
+			TotalMs:       r.TotalMs,
+			Formatted:     formatMs(r.TotalMs),
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"count":  len(tracks),
+		"from":   fromStr,
+		"to":     toStr,
+		"tracks": tracks,
+	})
+}
+
+/* ---------- listening time statistics (duration-aware sibling of /collection-stats) ---------- */
+func formatMs(ms int64) string {
+	mins := ms / 60000
+	return fmt.Sprintf("%dh %dm", mins/60, mins%60)
+}
+
+func GetListeningStats(c *gin.Context) {
+	daily, err := repository.GetDailyListeningBreakdown()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch daily breakdown", "details": err.Error()})
+		return
+	}
+	byPeriod, err := repository.GetListeningTimeByPeriod()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch listening time", "details": err.Error()})
+		return
+	}
+
+	dailyOut := make([]gin.H, len(daily))
+	for i, d := range daily {
+		dailyOut[i] = gin.H{
+			"date":      d.Date,
+			"total_ms":  d.TotalMs,
+			"formatted": formatMs(d.TotalMs),
+			"count":     d.Count,
+		}
+	}
+
+	listeningTime := gin.H{}
+	for period, ms := range byPeriod {
+		listeningTime[period] = gin.H{
+			"total_ms":  ms,
+			"formatted": formatMs(ms),
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"daily_breakdown_last_30_days": dailyOut,
+		"listening_time":               listeningTime,
+	})
+}
+
 /* ---------- collection statistics ---------- */
 func GetCollectionStats(c *gin.Context) {
 	now := time.Now()
@@ -248,6 +374,7 @@ func CollectRecentTracks() {
 			it.Track.Album.Name,
 			albumCoverURL,
 			genre,
+			it.Track.DurationMs,
 			it.PlayedAt,
 		)
 		if err != nil {

--- a/internal/models/track.go
+++ b/internal/models/track.go
@@ -36,16 +36,16 @@ type RecentlyLikedTracks struct {
 // Cron writes one row per item; no touch on tracks_on_repeat
 func InsertRecentlyPlayed(
 	spotifyID, name, artist, album string, albumCoverURL string, genre string,
-	playedAt time.Time,
+	durationMs int, playedAt time.Time,
 ) error {
 
 	_, err := repository.Pool.Exec(context.Background(), `
 		INSERT INTO recently_played
 		      (spotify_song_id, track_name, artist_name, album_name, album_cover_url, genre,
-		       played_at, source)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		       duration_ms, played_at, source)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		ON CONFLICT DO NOTHING`,
-		spotifyID, name, artist, album, albumCoverURL, genre, playedAt, "cron")
+		spotifyID, name, artist, album, albumCoverURL, genre, durationMs, playedAt, "cron")
 	return err
 }
 

--- a/internal/repository/db.go
+++ b/internal/repository/db.go
@@ -108,6 +108,7 @@ func ensureTablesExist() error {
 		album_name TEXT,
 		album_cover_url TEXT,
 		genre TEXT,
+		duration_ms INTEGER,
 		played_at TIMESTAMP NOT NULL,
 		source VARCHAR(50) DEFAULT 'cron',
 		created_at TIMESTAMP DEFAULT NOW(),
@@ -116,6 +117,10 @@ func ensureTablesExist() error {
 
 	if _, err := Pool.Exec(ctx, recentlyPlayedTable); err != nil {
 		return fmt.Errorf("failed to create recently_played table: %v", err)
+	}
+
+	if _, err := Pool.Exec(ctx, `ALTER TABLE recently_played ADD COLUMN IF NOT EXISTS duration_ms INTEGER`); err != nil {
+		return fmt.Errorf("failed to ensure duration_ms column: %v", err)
 	}
 
 	// Create useful indexes
@@ -215,6 +220,133 @@ func HasHistoricalData() (bool, error) {
 		return false, fmt.Errorf("failed to check historical data: %v", err)
 	}
 	return count > 0, nil
+}
+
+// DailyListeningStat is one day's row in /listening-stats daily_breakdown_last_30_days.
+type DailyListeningStat struct {
+	Date    string `json:"date"`
+	TotalMs int64  `json:"total_ms"`
+	Count   int    `json:"count"`
+}
+
+// GetDailyListeningBreakdown returns per-day aggregates for the last 30 days
+// (only days with at least one play are included).
+func GetDailyListeningBreakdown() ([]DailyListeningStat, error) {
+	query := `
+		SELECT
+			TO_CHAR(DATE(played_at), 'YYYY-MM-DD') AS date,
+			COALESCE(SUM(duration_ms), 0)          AS total_ms,
+			COUNT(*)                               AS count
+		FROM recently_played
+		WHERE played_at >= NOW() - INTERVAL '30 days'
+		GROUP BY DATE(played_at)
+		ORDER BY DATE(played_at) DESC
+	`
+	rows, err := Pool.Query(context.Background(), query)
+	if err != nil {
+		return nil, fmt.Errorf("failed daily listening breakdown: %v", err)
+	}
+	defer rows.Close()
+
+	results := make([]DailyListeningStat, 0, 30)
+	for rows.Next() {
+		var s DailyListeningStat
+		if err := rows.Scan(&s.Date, &s.TotalMs, &s.Count); err != nil {
+			return nil, err
+		}
+		results = append(results, s)
+	}
+	return results, nil
+}
+
+// GetListeningTimeByPeriod returns total_ms summed for each named period,
+// matching the periods used by /collection-stats.
+func GetListeningTimeByPeriod() (map[string]int64, error) {
+	query := `
+		SELECT
+			COALESCE(SUM(duration_ms) FILTER (WHERE played_at >= NOW() - INTERVAL '24 hours'), 0) AS last_24_hours,
+			COALESCE(SUM(duration_ms) FILTER (WHERE played_at >= NOW() - INTERVAL '7 days'),     0) AS last_week,
+			COALESCE(SUM(duration_ms) FILTER (WHERE played_at >= NOW() - INTERVAL '1 month'),    0) AS last_month,
+			COALESCE(SUM(duration_ms) FILTER (WHERE played_at >= NOW() - INTERVAL '3 months'),   0) AS last_3_months,
+			COALESCE(SUM(duration_ms),                                                            0) AS all_time
+		FROM recently_played
+	`
+	var l24, lw, lm, l3m, all int64
+	if err := Pool.QueryRow(context.Background(), query).Scan(&l24, &lw, &lm, &l3m, &all); err != nil {
+		return nil, fmt.Errorf("failed listening time by period: %v", err)
+	}
+	return map[string]int64{
+		"last_24_hours": l24,
+		"last_week":     lw,
+		"last_month":    lm,
+		"last_3_months": l3m,
+		"all_time":      all,
+	}, nil
+}
+
+// TopTrack is one row of the /top-tracks aggregation
+type TopTrack struct {
+	SpotifySongID string `json:"song_id"`
+	TrackName     string `json:"track_name"`
+	ArtistName    string `json:"artist_name"`
+	AlbumName     string `json:"album_name"`
+	AlbumCoverURL string `json:"album_cover_url"`
+	PlayCount     int    `json:"play_count"`
+	TotalMs       int64  `json:"total_ms"`
+}
+
+// GetTopTracks aggregates recently_played by song and returns the highest-played
+// tracks within the given window. Pass a zero time.Time to leave that bound open.
+// Tie-breaker: total_ms DESC, then spotify_song_id ASC for determinism.
+func GetTopTracks(from, to time.Time, limit int) ([]TopTrack, error) {
+	query := `
+		SELECT
+			spotify_song_id,
+			MAX(track_name)                     AS track_name,
+			COALESCE(MAX(artist_name), '')      AS artist_name,
+			COALESCE(MAX(album_name), '')       AS album_name,
+			COALESCE(MAX(album_cover_url), '')  AS album_cover_url,
+			COUNT(*)                            AS play_count,
+			COALESCE(SUM(duration_ms), 0)       AS total_ms
+		FROM recently_played
+		WHERE ($1::timestamp IS NULL OR played_at >= $1)
+		  AND ($2::timestamp IS NULL OR played_at <  $2)
+		GROUP BY spotify_song_id
+		ORDER BY play_count DESC, total_ms DESC, spotify_song_id ASC
+		LIMIT $3
+	`
+
+	var fromArg, toArg any
+	if !from.IsZero() {
+		fromArg = from
+	}
+	if !to.IsZero() {
+		toArg = to
+	}
+
+	rows, err := Pool.Query(context.Background(), query, fromArg, toArg, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query top tracks: %v", err)
+	}
+	defer rows.Close()
+
+	results := make([]TopTrack, 0, limit)
+	for rows.Next() {
+		var t TopTrack
+		if err := rows.Scan(
+			&t.SpotifySongID,
+			&t.TrackName,
+			&t.ArtistName,
+			&t.AlbumName,
+			&t.AlbumCoverURL,
+			&t.PlayCount,
+			&t.TotalMs,
+		); err != nil {
+			return nil, fmt.Errorf("scan top tracks row: %v", err)
+		}
+		results = append(results, t)
+	}
+	return results, nil
 }
 
 // GetArtistsByGenre returns unique artists from specified table that match the given genre

--- a/internal/services/client.go
+++ b/internal/services/client.go
@@ -59,9 +59,10 @@ func RefreshAccessToken(refreshToken string) (accessToken string, newRefreshTok 
 
 type PlayedItem struct {
 	Track struct {
-		ID    string `json:"id"`
-		Name  string `json:"name"`
-		Album struct {
+		ID         string `json:"id"`
+		Name       string `json:"name"`
+		DurationMs int    `json:"duration_ms"`
+		Album      struct {
 			Name   string       `json:"name"`
 			Images []AlbumImage `json:"images"`
 		} `json:"album"`


### PR DESCRIPTION
These two GET endpoints exist on the deployed image but had no source in the repo on any branch — likely lost when an editor crash discarded unsaved work. Rebuilt to match the live API's response shapes exactly, verified row-for-row against the development DB.

- /top-tracks?from=&to=&limit= aggregates recently_played by song, with count, summed duration_ms, and an "Xh Ym" formatted total. Tie-breaker is total_ms DESC (deterministic — the live API has unstable HashAggregate ordering as new rows are inserted).
- /listening-stats returns last-30-days daily breakdown plus listening time totals for 24h/week/month/3-months/all-time, all duration-aware.
- recently_played schema gains duration_ms (idempotent ADD COLUMN IF NOT EXISTS — already present on dev/prod DBs from a prior live migration).
- Cron writer (CollectRecentTracks) and both recovery scripts now capture and persist duration_ms from Spotify so locally-built containers stay consistent with the live data.